### PR TITLE
Fix/campaign tracking

### DIFF
--- a/lib/spree/chimpy/controller_filters.rb
+++ b/lib/spree/chimpy/controller_filters.rb
@@ -15,11 +15,16 @@ module Spree::Chimpy
     def set_mailchimp_params
       @mc_eid = params[:mc_eid] || session[:mc_eid]
       @mc_cid = params[:mc_cid] || session[:mc_cid]
+
+      # The MC params need to be retained in the SESSION for proper tracking
+      # until they can be attached to an Order
+      session[:mc_eid] = mc_eid
+      session[:mc_cid] = mc_cid
     end
 
     def mailchimp_params?
       (!mc_eid.nil? || !mc_cid.nil?) &&
-        (!session[:order_id].nil? || !params[:record_mc_details].nil?)
+        (!current_order.nil? || !params[:record_mc_details].nil?)
     end
 
     def find_mail_chimp_params

--- a/lib/spree/chimpy/interface/products.rb
+++ b/lib/spree/chimpy/interface/products.rb
@@ -86,15 +86,21 @@ module Spree::Chimpy
       end
 
       def self.variant_hash(variant)
-        {
+        data = {
           id: mailchimp_variant_id(variant),
           title: variant.name,
           sku: variant.sku,
           url: product_url_or_default(variant.product),
           price: variant.price.to_f,
-          image_url: variant_image_url(variant),
+
           inventory_quantity: variant.total_on_hand == Float::INFINITY ? 999 : variant.total_on_hand
         }
+
+        if variant.images.any?
+          data[:image_url] = variant_image_url variant
+        end
+        
+        data
       end
 
       def self.variant_image_url(variant)


### PR DESCRIPTION
Fix a bug in campaign tracking that prevents Spree Orders from being attached to MailChimp Campaigns
-- Retain MailChimp query string parameters in the `session` hash until they can be correctly assigned to an order