### PR TITLE
Fix/169/2/cart integration

### DIFF
--- a/lib/spree/chimpy/interface/order_upserter.rb
+++ b/lib/spree/chimpy/interface/order_upserter.rb
@@ -1,5 +1,6 @@
 require_relative 'customer_upserter'
 require_relative 'products'
+require_relative 'spree_order_upserter'
 
 module Spree::Chimpy
   module Interface


### PR DESCRIPTION
Fix errors in `order_upserter` due to disabled autoloading in production environments