### PR TITLE
fix(cart_upserter): Remove carts in MailChimp if they have no line items

### DIFF
--- a/lib/spree/chimpy/interface/cart_upserter.rb
+++ b/lib/spree/chimpy/interface/cart_upserter.rb
@@ -14,7 +14,8 @@ module Spree::Chimpy
       end
 
       def perform_upsert
-        if (@order.completed?)
+        if (@order.completed? || !@order.line_items.any?)
+          # NOTE: If an order is complete or has no line items, remove the associated cart from MailChimp
           remove_cart
         else
           add_or_update_cart


### PR DESCRIPTION
Modify the `cart_upserter` to remove empty carts in MailChimp

https://trello.com/c/ujQ54WKs/929-as-a-5-stoner-i-should-make-abandon-carts-work