### PR TITLE
feat(orders): Add the apbility for admins to manually push orders

### DIFF
--- a/app/controllers/spree/admin/orders_controller_decorator.rb
+++ b/app/controllers/spree/admin/orders_controller_decorator.rb
@@ -1,0 +1,20 @@
+Spree::Admin::OrdersController.class_eval do
+
+  # Adds the ability to manually queue all orders with at least one line item to
+  # sync with MailChimp. This is designed to serve two purposes:
+  #
+  #       1.  It provides a manual override that can push order/cart data into MailChimp
+  #           for data that existed BEFORE this integration was added to Spree
+  #
+  #       2.  It can be used to perform a bulk sync if the automated process needs to be
+  #           turned off for any reason
+  def push_all_to_mail_chimp
+    Spree::Order.where.not(item_count: 0).each do |order|
+      order.notify_mail_chimp
+    end
+
+    flash[:success] = 'MailChimp sync queued successfully'
+    redirect_to admin_orders_url()
+  end
+
+end

--- a/app/overrides/order_index.rb
+++ b/app/overrides/order_index.rb
@@ -1,0 +1,5 @@
+Deface::Override.new(:virtual_path => "spree/admin/orders/index",
+                     :name         => "order_index_buttons",
+                     :insert_after => "erb:contains('page_actions')",
+                     text: "<%= link_to('Sync with MailChimp', mail_chimp_push_orders_path(), class: 'btn btn-primary') %>"
+                   )

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Spree::Core::Engine.add_routes do
+  get 'admin/chimpy/orders/push', to: 'admin/orders#push_all_to_mail_chimp', as: 'mail_chimp_push_orders'
+
   namespace :chimpy, path: "" do
     resource :subscribers, only: [:create]
   end

--- a/lib/tasks/spree_chimpy.rake
+++ b/lib/tasks/spree_chimpy.rake
@@ -17,7 +17,7 @@ namespace :spree_chimpy do
         print '.'
         batch.each do |order|
           begin
-            order.send_order_to_mail_chimp
+            order.notify_mail_chimp
           rescue => exception
             if defined?(::Delayed::Job)
               raise exception


### PR DESCRIPTION
Add a button on the Orders index that allows admin users to manually queue all orders to sync with
MailChimp

https://trello.com/c/zz1IUXSg/955-as-an-admin-i-should-be-able-to-push-incomplete-orders-into-mailchimp