### PR TITLE
fix(order_decorator): Fix error in completed order sync

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -2,8 +2,7 @@ Spree::Order.class_eval do
   has_one :source, class_name: 'Spree::Chimpy::OrderSource'
 
   around_save :handle_cancelation
-  after_create :notify_mail_chimp
-  after_save :notify_mail_chimp
+  after_commit :notify_mail_chimp
 
   def notify_mail_chimp
 


### PR DESCRIPTION
Fix an issue where completed orders would sometimes be pushed to MC as carts due to the sync firing
_before_ `completed_at` was set. In such cases, `order.completed?` returned false. Modify the
`notify_mail_chimp` method to fire `after_commit` rather than `after_save` and `after_create` to
ensure completed orders always get updated.

https://trello.com/c/cH3LONRp/276-as-a-developer-i-should-look-in-to-the-mailchimp-sync